### PR TITLE
Adds support to configurable products.

### DIFF
--- a/Observer/CatalogControllerProductInitAfter.php
+++ b/Observer/CatalogControllerProductInitAfter.php
@@ -34,8 +34,15 @@ class CatalogControllerProductInitAfter implements ObserverInterface {
 		if (!$this->_fbPixelHelper->isViewProductPixelEnabled() || !$product) {
 			return $this;
 		}
+
+		//verify if the product is an bundle product
+		$contentType = 'product';
+		if($product->getTypeId() == 'configurable'){
+			$contentType = 'product_group';
+		}
+
 		$data = [
-			'content_type' => 'product',
+			'content_type' => $contentType,
 			'content_ids' => [$product->getSku()],
 			'value' => $product->getFinalPrice(),
 			'currency' => $this->_fbPixelHelper->getCurrencyCode(),

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -47,8 +47,14 @@ class SalesQuoteProductAddAfter implements ObserverInterface {
 			$candidates['value'] += $item->getProduct()->getFinalPrice() * $item->getProduct()->getQty();
 		}
 
+		//verify if the product is an bundle product
+		$contentType = 'product';
+		if($product->getTypeId() == 'configurable'){
+			$contentType = 'product_group';
+		}
+
 		$data = array(
-			'content_type' => 'product',
+			'content_type' => $contentType,
 			'content_ids' => $candidates['content_ids'],
 			'value' => $candidates['value'],
 			'currency' => $this->_fbPixelHelper->getCurrencyCode()

--- a/Observer/WishlistAddProduct.php
+++ b/Observer/WishlistAddProduct.php
@@ -35,8 +35,14 @@ class WishlistAddProduct implements ObserverInterface {
 			return $this;
 		}
 
+		//verify if the product is an bundle product
+		$contentType = 'product';
+		if($product->getTypeId() == 'configurable'){
+			$contentType = 'product_group';
+		}
+
 		$data = [
-			'content_type' => 'product',
+			'content_type' => $contentType,
 			'content_ids' => [$product->getSku()],
 			'value' => $product->getFinalPrice(),
 			'currency' => $this->_fbPixelHelper->getCurrencyCode()


### PR DESCRIPTION
Configurable products should be sent to Facebook as several products, one for each variation (such as color and size for example), to inform that it is a configurable product, the group_id field is required, see: https://developers.facebook.com/docs/marketing-api/dynamic-product-ads/product-catalog#setup-product-feed.

In magento store, when it comes to a configurable product, the "content_type" should be "product_group".