### PR TITLE
Remove PHP requirements from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,6 @@
 {
   "name": "cadence/fbpixel-m2",
   "description": "Facebook Pixel & Events Support For Magento 2.x",
-  "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0"
-  },
   "keywords": [
     "Magento",
     "Magento 2",


### PR DESCRIPTION
It doesn't make sense to add PHP requirements in composer.json as they are now: (php 5.5, 5.6, 7.0, 7.1)
- this configuration prevents from using the package in PHP 7.2
- Magento 2 doesnt support php 5.5. or 5.6, so it doesnt make sense to specify it here
- This is M2 module, so we should rely on magento PHP requirements
- for every new PHP version this line needs to be updated

There are few forks already which changes just that in the module, so it's painful for other people as well. See:
https://github.com/AndreaShining/m2-fbpixel/commit/a2ac1f6404bdd5b1c29aa60cbde65cbf94f1c797
https://github.com/angeldm/m2-fbpixel/commit/5452d881d85f157a4600b8fe49a0e881bcd3e974
https://github.com/Archipel/m2-fbpixel/commit/553e667d29bf091c481c0b96f462c41ec2dc7469